### PR TITLE
run.sh: force MacOs to run the executable natively when on Apple Silicon

### DIFF
--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -324,7 +324,7 @@ if [ -n "${is_apple_silicon}" ]; then
     # the executable is universal, supporting both x86_64 and arm64, MacOs will still run it as x86_64
     # if the parent process is running as x86.
     # arch also strips the DYLD_INSERT_LIBRARIES env var so we have to pass that in manually
-    arch -e DYLD_INSERT_LIBRARIES="${DYLD_INSERT_LIBRARIES}" "$executable_path" "$@"
+    exec arch -e DYLD_INSERT_LIBRARIES="${DYLD_INSERT_LIBRARIES}" "$executable_path" "$@"
 else
     exec "$executable_path" "$@"
 fi


### PR DESCRIPTION
This is a fix for #78 which updates `run.sh` to use `arch` instead of `exec` when on Apple Silicon to allow the executable to run natively when the run script is invoked from a process running on Rosetta.

I've tested the script itself somewhat thoroughly with a custom exec and custom dylib for injection to confirm that both the executable is ran natively and there's no impact to environment variables. This was done with x86_64, arm64, and universal versions of the exec as well as laughing the script directly from a terminal running natively & via Rosetta and having another process run the script via exec'ing `sh`. In all cases the executable and dylib were loaded natively as arm64.

e.g. running a small x86_64 `summon` executable via Rosetta that just uses `execvp` to run the script.
```
❯ ./summon
[summon] running as x86_64
; original process is run via Rosetta ^

[inject.dylib] dylib injected in /Users/nskobelevs/Projects/dylib/main.app/Contents/MacOS/main, architecture = arm64
; the dylib gets loaded as arm64
[inject.dylib] DOORSTOP_ENABLED = 1
[inject.dylib] DOORSTOP_TARGET_ASSEMBLY = /Users/nskobelevs/Projects/dylib/Doorstop.dll
[inject.dylib] DOORSTOP_BOOT_CONFIG_OVERRIDE =
[inject.dylib] DOORSTOP_IGNORE_DISABLED_ENV = 0
[inject.dylib] DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE =
[inject.dylib] DOORSTOP_MONO_DEBUG_ENABLED = 0
[inject.dylib] DOORSTOP_MONO_DEBUG_ADDRESS = 127.0.0.1:10000
[inject.dylib] DOORSTOP_MONO_DEBUG_SUSPEND = 0
[inject.dylib] DOORSTOP_CLR_RUNTIME_CORECLR_PATH = .dylib
[inject.dylib] DOORSTOP_CLR_CORLIB_DIR =
[inject.dylib] LD_PRELOAD = inject.dylib
[inject.dylib] DYLD_INSERT_LIBRARIES = inject.dylib
; environment variables in the dylib are intact

[main] running as arm64
; executable itself ran natively
[main] DOORSTOP_ENABLED = 1
[main] DOORSTOP_TARGET_ASSEMBLY = /Users/nskobelevs/Projects/dylib/Doorstop.dll
[main] DOORSTOP_BOOT_CONFIG_OVERRIDE =
[main] DOORSTOP_IGNORE_DISABLED_ENV = 0
[main] DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE =
[main] DOORSTOP_MONO_DEBUG_ENABLED = 0
[main] DOORSTOP_MONO_DEBUG_ADDRESS = 127.0.0.1:10000
[main] DOORSTOP_MONO_DEBUG_SUSPEND = 0
[main] DOORSTOP_CLR_RUNTIME_CORECLR_PATH = .dylib
[main] DOORSTOP_CLR_CORLIB_DIR =
[main] LD_PRELOAD = inject.dylib
[main] DYLD_INSERT_LIBRARIES = inject.dylib
; environment variables for the main exec itself remain intact
```

Also tested practically with doorstop and BepInEx 5 running Silksong through Steam - the game launches natively with BepInEx loading all expected plugins meaning doorstop was successful.

The main thing I'm not sure about if any special handling is needed for the `Special case: program is launched via Steam` case - I've been laughing the game via Steam with launch options but I don't think it applied here, not sure if that might be only for Linux?