### PR TITLE
Only output on nix verbose builds and only output to stderr

### DIFF
--- a/src/nix/entrypoint.c
+++ b/src/nix/entrypoint.c
@@ -117,7 +117,7 @@ __attribute__((constructor)) void doorstop_ctor() {
     }
 
     if (plthook_replace(hook, "dlsym", &dlsym_hook, NULL) != 0)
-        printf("Failed to hook dlsym, ignoring it. Error: %s\n",
+        LOG("Failed to hook dlsym, ignoring it. Error: %s",
                plthook_error());
 
     if (config.boot_config_override) {
@@ -132,11 +132,11 @@ __attribute__((constructor)) void doorstop_ctor() {
 
 #if !defined(__APPLE__)
             if (plthook_replace(hook, "fopen64", &fopen64_hook, NULL) != 0)
-                printf("Failed to hook fopen64, ignoring it. Error: %s\n",
+                LOG("Failed to hook fopen64, ignoring it. Error: %s",
                        plthook_error());
 #endif
             if (plthook_replace(hook, "fopen", &fopen_hook, NULL) != 0)
-                printf("Failed to hook fopen, ignoring it. Error: %s\n",
+                LOG("Failed to hook fopen, ignoring it. Error: %s",
                        plthook_error());
         } else {
             LOG("The boot.config file won't be overriden because the provided "
@@ -146,11 +146,11 @@ __attribute__((constructor)) void doorstop_ctor() {
     }
 
     if (plthook_replace(hook, "fclose", &fclose_hook, NULL) != 0)
-        printf("Failed to hook fclose, ignoring it. Error: %s\n",
+        LOG("Failed to hook fclose, ignoring it. Error: %s",
                plthook_error());
 
     if (plthook_replace(hook, "dup2", &dup2_hook, NULL) != 0)
-        printf("Failed to hook dup2, ignoring it. Error: %s\n",
+        LOG("Failed to hook dup2, ignoring it. Error: %s",
                plthook_error());
 
 #if defined(__APPLE__)
@@ -162,7 +162,7 @@ __attribute__((constructor)) void doorstop_ctor() {
     void *mono_handle = plthook_handle_by_name("libmono");
 
     if (plthook_replace(hook, "mono_jit_init_version", &init_mono, NULL) != 0)
-        printf("Failed to hook jit_init_version, ignoring it. This is probably fine unless you see other errors. Error: %s\n",
+        LOG("Failed to hook jit_init_version, ignoring it. This is probably fine unless you see other errors. Error: %s",
                plthook_error());
     else if (mono_handle)
         load_mono_funcs(mono_handle);

--- a/src/nix/logger.h
+++ b/src/nix/logger.h
@@ -2,17 +2,17 @@
 #define LOGGER_NIX_H
 #if VERBOSE
 
-#define LOG(message, ...) printf("[Doorstop] " message "\n", ##__VA_ARGS__)
+#define LOG(message, ...) fprintf(stderr, "[Doorstop] " message "\n", ##__VA_ARGS__)
 
 #define ASSERT_F(test, message, ...)                                           \
     if (!(test)) {                                                             \
-        printf("[Doorstop][Fatal] " message "\n", ##__VA_ARGS__);              \
+        fprintf(stderr, "[Doorstop][Fatal] " message "\n", ##__VA_ARGS__);     \
         exit(1);                                                               \
     }
 
 #define ASSERT(test, message)                                                  \
     if (!(test)) {                                                             \
-        printf("[Doorstop][Fatal] " message "\n");                             \
+        fprintf(stderr, "[Doorstop][Fatal] " message "\n");                    \
         exit(1);                                                               \
     }
 


### PR DESCRIPTION
Prevent any output on non verbose nix builds and only output to stderr on verbose builds to avoid introducing unexpected output from non unity processes that UnityDoorstop gets injected into.

The behavior can be observed in 4.4.0 and 4.4.1 with the following test case.
```
$ DOORSTOP_ENABLED=1 LD_PRELOAD=./libdoorstop.so cat <(echo "This should be the only output")
Failed to hook dlsym, ignoring it. Error: no such function: dlsym
Failed to hook dup2, ignoring it. Error: no such function: dup2
This should be the only output
```
