### PR TITLE
Honor ignore_disable_switch for inherited DOORSTOP_INITIALIZED

### DIFF
--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -10,12 +10,22 @@
 
 bool_t mono_debug_init_called = FALSE;
 bool_t mono_is_net35 = FALSE;
+static bool_t doorstop_bootstrapped = FALSE;
 
 void mono_doorstop_bootstrap(void *mono_domain) {
-    if (getenv(TEXT("DOORSTOP_INITIALIZED"))) {
+    if (doorstop_bootstrapped) {
+        LOG("Doorstop already bootstrapped in this process, skipping!");
+        return;
+    }
+    // Steam (and other launchers) can leak DOORSTOP_INITIALIZED into a new
+    // game process, the same env-isolation issue ignore_disable_switch already
+    // covers for DOORSTOP_DISABLE. Honor that switch here; use the static flag
+    // above for genuine in-process re-entry.
+    if (getenv(TEXT("DOORSTOP_INITIALIZED")) && !config.ignore_disabled_env) {
         LOG("DOORSTOP_INITIALIZED is set! Skipping!");
         return;
     }
+    doorstop_bootstrapped = TRUE;
     setenv(TEXT("DOORSTOP_INITIALIZED"), TEXT("TRUE"), TRUE);
 
     mono.thread_set_main(mono.thread_current());

--- a/src/nix/entrypoint.c
+++ b/src/nix/entrypoint.c
@@ -95,6 +95,11 @@ int dup2_hook(int od, int nd) {
 __attribute__((constructor)) void doorstop_ctor() {
     init_logger();
     load_config();
+    if (config.ignore_disabled_env) {
+        unsetenv("DOORSTOP_INITIALIZED");
+        unsetenv("DOORSTOP_DISABLE");
+        LOG("Cleared inherited DOORSTOP_INITIALIZED / DOORSTOP_DISABLE");
+    }
 
     if (!config.enabled) {
         LOG("Doorstop not enabled! Skipping!");

--- a/src/windows/entrypoint.c
+++ b/src/windows/entrypoint.c
@@ -284,6 +284,11 @@ BOOL WINAPI DllEntry(HINSTANCE hInstDll, DWORD reasonForDllLoad,
 
     load_config();
     LOG("Config loaded");
+    if (config.ignore_disabled_env) {
+        SetEnvironmentVariableW(L"DOORSTOP_INITIALIZED", NULL);
+        SetEnvironmentVariableW(L"DOORSTOP_DISABLE", NULL);
+        LOG("Cleared inherited DOORSTOP_INITIALIZED / DOORSTOP_DISABLE");
+    }
 
     redirect_output_log(paths);
 


### PR DESCRIPTION
## Summary

`ignore_disable_switch` already exists so launchers that break environment isolation (Steam is called out in `config.h`) cannot kill Doorstop with `DOORSTOP_DISABLE`. The same launchers also leak `DOORSTOP_INITIALIZED`.

`mono_doorstop_bootstrap` treats any inherited `DOORSTOP_INITIALIZED` as "we already ran" and returns before loading the target assembly. Verbose log from a Steam-launched Unity Mono game (Legend of Mortal / 活侠传):

```
CONFIG: General.ignore_disable_switch = true
Doorstop enabled!
Installing IAT hooks
Got mono_jit_init_version at ...
Starting mono domain "Unity Root Domain"
DOORSTOP_INITIALIZED is set! Skipping!
```

BepInEx never reaches `Doorstop.Entrypoint.Start`.

This also matches #73 (game process restarts itself and inherits both variables).

## Change

- After loading config, if `ignore_disable_switch` is on, clear inherited `DOORSTOP_INITIALIZED` and `DOORSTOP_DISABLE` (Windows + *nix).
- Gate in-process re-entry with a static flag instead of trusting a pre-set env var.
- Still skip when `DOORSTOP_INITIALIZED` is set and the switch is off (existing behavior).

## Tested

Unity 2020.3 Mono x86, Steam app 1859910, BepInEx 6 BE, `ignore_disable_switch = true`. After this change Doorstop logs `Opening assembly` and BepInEx chainloader starts without running the game elevated.

## Notes

Not changing the default of `ignore_disable_switch` (still `false`). Callers that already set it for Steam should get the rest of the intended behavior.